### PR TITLE
Fix Linux build. Require C99 & add POSIX macro

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,8 +1,8 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause-FreeBSD
 #
-
-CFLAGS+=	-g3 -ggdb -Werror -Wall -Wextra -Wformat-security -Waggregate-return -Wbad-function-cast -Wcast-align -Wdeclaration-after-statement -Wdisabled-optimization -Wfloat-equal -Winline -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wold-style-definition -Wpacked -Wpointer-arith -Wredundant-decls -Wstrict-prototypes -Wunreachable-code -Wwrite-strings
+.POSIX:
+CFLAGS+=	-g3 -ggdb -Werror -Wall -Wextra -Wformat-security -Waggregate-return -Wbad-function-cast -Wcast-align -Wdeclaration-after-statement -Wdisabled-optimization -Wfloat-equal -Winline -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wold-style-definition -Wpacked -Wpointer-arith -Wredundant-decls -Wstrict-prototypes -Wunreachable-code -Wwrite-strings -std=c99
 
 all: nsfinfo
 

--- a/nsfinfo.c
+++ b/nsfinfo.c
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
  */
 
+#define _XOPEN_SOURCE 600
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <fcntl.h>


### PR DESCRIPTION
Fixes #5 

* Add POSIX macro, see `man 7 feature_test_macros`
* Require C99
* Added `.POSIX:` to adhere to the makefile standard
> According to the standard, in order to get reliable POSIX behavior, the first non-comment line of the Makefile must be .POSIX.
https://nullprogram.com/blog/2017/08/20/


