### PR TITLE
Use C89 declaration

### DIFF
--- a/nsfinfo.c
+++ b/nsfinfo.c
@@ -58,6 +58,7 @@ my_MD5_File(const char *filename)
 {
 	FILE *fd;
 	size_t filelen;
+	unsigned int i;
 	unsigned char *filebuf = NULL;
 	MD5_CTX c;
 	BYTE hash[MD5_BLOCK_SIZE];
@@ -102,7 +103,7 @@ my_MD5_File(const char *filename)
 	hashstr = calloc((MD5_BLOCK_SIZE * 2) + 1, 1);
 	hashstrp = &hashstr[0];
 
-	for (unsigned int i = 0; i < MD5_BLOCK_SIZE; i++) {
+	for (i = 0; i < MD5_BLOCK_SIZE; i++) {
 		hashstrp += sprintf(hashstrp, "%02x", hash[i]);
 	}
 
@@ -114,6 +115,7 @@ my_SHA256_File(const char *filename)
 {
 	FILE *fd;
 	size_t filelen;
+	unsigned int i;
 	unsigned char *filebuf = NULL;
 	SHA256_CTX c;
 	BYTE hash[SHA256_BLOCK_SIZE];
@@ -158,7 +160,7 @@ my_SHA256_File(const char *filename)
 	hashstr = calloc((SHA256_BLOCK_SIZE * 2) + 1, 1);
 	hashstrp = &hashstr[0];
 
-	for (unsigned int i = 0; i < SHA256_BLOCK_SIZE; i++) {
+	for (i = 0; i < SHA256_BLOCK_SIZE; i++) {
 		hashstrp += sprintf(hashstrp, "%02x", hash[i]);
 	}
 


### PR DESCRIPTION
Fixes #5. Replaces previous PR #6 

> The solution is to simply declare unsigned int i at the top of the function/with the other variable definitions a la C89. Please change your PR to do that instead and verify it works everywhere that you're testing it.

https://github.com/koitsu/nsfinfo/pull/6#issuecomment-1631481185

Tested and compiled using:
* gcc versions 4.6.3 and 10.2.1
* gnu make versions 3.81 and 4.3

Please note that C99-style comments are still present in `md5.*` and `sha25.*`. However these don't interfere with the default behaviour of old versions of GCC (4.6.3).